### PR TITLE
load_icon_themes_from_dir: never reuse GKeyFile object

### DIFF
--- a/src/icon-theme.c
+++ b/src/icon-theme.c
@@ -46,7 +46,7 @@ static void icon_theme_free(IconTheme* theme)
     g_slice_free(IconTheme, theme);
 }
 
-void load_icon_themes_from_dir(const char* base_dir, const char* theme_dir, GKeyFile* kf)
+void load_icon_themes_from_dir(const char* base_dir, const char* theme_dir)
 {
     /* NOTE:
      * 1. theoratically, base_dir is identical to theme_dir
@@ -75,6 +75,7 @@ void load_icon_themes_from_dir(const char* base_dir, const char* theme_dir, GKey
                 IconTheme* theme = g_slice_new0(IconTheme);
                 char* index_theme;
                 char* cursor_subdir;
+                GKeyFile* kf = g_key_file_new();
 
                 theme->name = g_strdup(name);
                 index_theme = g_build_filename(theme_dir, name, "index.theme", NULL);
@@ -97,6 +98,7 @@ void load_icon_themes_from_dir(const char* base_dir, const char* theme_dir, GKey
                 else
                     theme->disp_name = theme->name;
                 g_free(index_theme);
+                g_key_file_free(kf);
 
                 cursor_subdir = g_build_filename(theme_dir, name, "cursors", NULL);
                 /* it contains a cursor theme */
@@ -119,13 +121,11 @@ static void load_icon_themes()
 {
     int n, i;
     gtk_icon_theme_get_search_path(gtk_icon_theme_get_default(), &icon_theme_dirs, &n);
-    GKeyFile* kf = g_key_file_new();
     for(i = 0; i < n; ++i)
     {
-        load_icon_themes_from_dir(icon_theme_dirs[i], icon_theme_dirs[i], kf);
+        load_icon_themes_from_dir(icon_theme_dirs[i], icon_theme_dirs[i]);
         /* g_debug("icon_theme_dirs[%d] = %s", i, icon_theme_dirs[i]); */
     }
-    g_key_file_free(kf);
 }
 
 

--- a/src/icon-theme.h
+++ b/src/icon-theme.h
@@ -40,7 +40,7 @@ typedef struct
 }IconTheme;
 
 void icon_theme_init(GtkBuilder* b);
-void load_icon_themes_from_dir(const char* base_dir, const char* theme_dir, GKeyFile* kf);
+void load_icon_themes_from_dir(const char* base_dir, const char* theme_dir);
 
 gint icon_theme_cmp_name(IconTheme* t, const char* name);
 gint icon_theme_cmp_disp_name(IconTheme* t1, IconTheme* t2);

--- a/src/utils.c
+++ b/src/utils.c
@@ -159,11 +159,9 @@ _failed:
         {
             /* move files in tmp_dir to user_icons_dir */
             GDir* dir;
-            GKeyFile* kf = g_key_file_new();
 
             /* convert the themes in the dir to IconTheme structs and add them to app.icon_themes list */
-            load_icon_themes_from_dir(user_icons_dir, tmp_dir, kf);
-            g_key_file_free(kf);
+            load_icon_themes_from_dir(user_icons_dir, tmp_dir);
 
             /* now really move this themes to $XDG_DATA_HOME/icons dir and also update the GUI */
             dir = g_dir_open(tmp_dir, 0, NULL);


### PR DESCRIPTION
As written on:
https://developer.gnome.org/glib/stable/glib-Key-value-file-parser.html#g-key-file-load-from-file
an empty GKeyFile object must be passed to g_key_file_load_from_file .

========================================================
Again, like https://github.com/lxde/lxsession/pull/27 , on Fedora 34 (using `glib2-2.68.0-1.fc34.x86_64`), `lxappearance` immediately segfaults like:
```
[tasaka1@localhost x86_64]$ gdb --args lxappearance 
GNU gdb (GDB) Fedora 10.1-10.fc34

(gdb) r
Starting program: /usr/bin/lxappearance 

Thread 1 "lxappearance" received signal SIGSEGV, Segmentation fault.
g_key_file_locale_is_interesting (locale=0x55555584b650 "af", key_file=0x5555558034f0) at ../glib/gkeyfile.c:1241
1241	  for (i = 0; key_file->locales[i] != NULL; i++)
Missing separate debuginfos, use: dnf debuginfo-install adwaita-gtk2-theme-3.28-12.fc34.x86_64 atk-2.36.0-3.fc34.x86_64 bzip2-libs-1.0.8-6.fc34.x86_64 cairo-1.17.4-3.fc34.x86_64 fontconfig-2.13.93-5.fc34.x86_64 freetype-2.10.4-3.fc34.x86_64 fribidi-1.0.10-4.fc34.x86_64 gdk-pixbuf2-2.42.2-2.fc34.x86_64 graphite2-1.3.14-7.fc34.x86_64 harfbuzz-2.7.4-3.fc34.x86_64 libXau-1.0.9-6.fc34.x86_64 libXcomposite-0.4.5-5.fc34.x86_64 libXcursor-1.2.0-5.fc34.x86_64 libXdamage-1.1.5-5.fc34.x86_64 libXext-1.3.4-6.fc34.x86_64 libXfixes-5.0.3-14.fc34.x86_64 libXi-1.7.10-6.fc34.x86_64 libXinerama-1.1.4-8.fc34.x86_64 libXrandr-1.5.2-6.fc34.x86_64 libXrender-0.9.10-14.fc34.x86_64 libblkid-2.36.2-1.fc34.x86_64 libbrotli-1.0.9-4.fc34.x86_64 libdatrie-0.2.13-1.fc34.x86_64 libffi-3.1-28.fc34.x86_64 libmount-2.36.2-1.fc34.x86_64 libpng-1.6.37-8.fc34.x86_64 libselinux-3.2-1.fc34.x86_64 libthai-0.1.28-6.fc34.x86_64 libxcb-1.13.1-7.fc34.x86_64 libxml2-2.9.10-10.fc34.x86_64 pcre-8.44-3.fc34.1.x86_64 pixman-0.40.0-3.fc34.x86_64 xz-libs-5.2.5-5.fc34.x86_64 zlib-1.2.11-24.fc34.x86_64
(gdb) bt
#0  g_key_file_locale_is_interesting (locale=0x55555584b650 "af", key_file=0x5555558034f0) at ../glib/gkeyfile.c:1241
#1  g_key_file_parse_key_value_pair (error=0x7fffffffcc40, length=<optimized out>, line=<optimized out>, key_file=0x5555558034f0) at ../glib/gkeyfile.c:1427
#2  g_key_file_parse_line (error=0x7fffffffcc38, length=<optimized out>, line=<optimized out>, key_file=0x5555558034f0) at ../glib/gkeyfile.c:1273
#3  g_key_file_flush_parse_buffer (key_file=key_file@entry=0x5555558034f0, error=error@entry=0x7fffffffcca0) at ../glib/gkeyfile.c:1542
#4  0x00007ffff76d6cdc in g_key_file_parse_data
    (key_file=0x5555558034f0, data=0x7fffffffcda0 "[Icon Theme]\nName=Mist\nName[af]=Mis\nName[ar]=غشى\nName[as]=কুঁৱলী\nName[ast]=Ñeblina\nName[az]=Çən\nName[be]=Туман\nName[be@latin]=Mist\nName[bg]=Мъгла\nName[bn]=কুয়া", <incomplete sequence \340\246>..., length=4096, error=0x7fffffffcd08) at ../glib/gkeyfile.c:1496
#5  0x00007ffff76d6f59 in g_key_file_load_from_fd (key_file=key_file@entry=0x5555558034f0, fd=fd@entry=9, flags=flags@entry=G_KEY_FILE_NONE, error=error@entry=0x7fffffffddf0)
    at ../glib/gkeyfile.c:857
#6  0x00007ffff76d7054 in g_key_file_load_from_file (key_file=0x5555558034f0, file=<optimized out>, flags=G_KEY_FILE_NONE, error=0x0) at ../glib/gkeyfile.c:924
#7  0x000055555555d55e in load_icon_themes_from_dir (base_dir=0x55555566d330 "/usr/share/icons", theme_dir=0x55555566d330 "/usr/share/icons", kf=0x5555558034f0)
    at /usr/src/debug/lxappearance-0.6.3-12.100.D20200807gitd132fdd8.fc35.x86_64/lxappearance/src/icon-theme.c:84
#8  0x000055555555d892 in load_icon_themes () at /usr/src/debug/lxappearance-0.6.3-12.100.D20200807gitd132fdd8.fc35.x86_64/lxappearance/src/icon-theme.c:125
#9  icon_theme_init (b=<optimized out>) at /usr/src/debug/lxappearance-0.6.3-12.100.D20200807gitd132fdd8.fc35.x86_64/lxappearance/src/icon-theme.c:247
#10 0x000055555555abaf in main (argc=<optimized out>, argv=<optimized out>)
    at /usr/src/debug/lxappearance-0.6.3-12.100.D20200807gitd132fdd8.fc35.x86_64/lxappearance/src/lxappearance.c:688
```