### PR TITLE
on_remove_theme_clicked: initialize both variable correctly

### DIFF
--- a/src/icon-theme.c
+++ b/src/icon-theme.c
@@ -171,7 +171,6 @@ static void on_remove_theme_clicked(GtkButton* btn, gpointer user_data)
     if(gtk_tree_selection_get_selected(sel, &model, &it))
     {
         IconTheme* theme;
-        gboolean both = theme->has_icon && theme->has_cursor;
 
         if(gtk_tree_model_iter_n_children(model, NULL) < 2)
         {
@@ -183,6 +182,7 @@ static void on_remove_theme_clicked(GtkButton* btn, gpointer user_data)
         gtk_tree_model_get(model, &it, 1, &theme, -1);
         if(remove_icon_theme(GTK_WINDOW(gtk_widget_get_toplevel(GTK_WIDGET(btn))), theme))
         {
+            gboolean both = theme->has_icon && theme->has_cursor;
             gtk_list_store_remove(GTK_LIST_STORE(model), &it);
 
             /* select the first theme */


### PR DESCRIPTION
In on_remove_theme_clicked: both variable is used uninitialized, which causes lxappearance segfault
when removing theme. Initialize this correctly.

=============================================================
Ref: https://sourceforge.net/p/lxde/bugs/866/  
Actually this causes lxappearance segfault when trying 
* Move to "Icon Theme" tab
* Select one icon theme
* Click "Remove" icon

Then:
```
Thread 1 "lxappearance" received signal SIGSEGV, Segmentation fault.
0x000055555555e904 in on_remove_theme_clicked (btn=0x555555750e40, user_data=<optimized out>)
    at /home/tasaka1/rpmbuild/fedora-specific/LXDE/lxappearance/rawhide/lxappearance-0.6.3/lxappearance/src/icon-theme.c:174
174	        gboolean both = theme->has_icon && theme->has_cursor;
Missing separate debuginfos, use: dnf debuginfo-install adwaita-gtk2-theme-3.28-12.fc34.x86_64 atk-2.36.0-3.fc34.x86_64 bzip2-libs-1.0.8-6.fc34.x86_64 cairo-1.17.4-3.fc34.x86_64 cairo-gobject-1.17.4-3.fc34.x86_64 dbus-libs-1.12.20-3.fc34.x86_64 fontconfig-2.13.93-5.fc34.x86_64 freetype-2.10.4-3.fc34.x86_64 fribidi-1.0.10-4.fc34.x86_64 gdk-pixbuf2-2.42.2-2.fc34.x86_64 graphite2-1.3.14-7.fc34.x86_64 gvfs-client-1.47.91-1.fc34.x86_64 harfbuzz-2.7.4-3.fc34.x86_64 ibus-gtk2-1.5.24-1.fc34.x86_64 ibus-libs-1.5.24-1.fc34.x86_64 imlib2-1.6.1-3.fc34.x86_64 libICE-1.0.10-6.fc34.x86_64 libSM-1.2.3-8.fc34.x86_64 libXau-1.0.9-6.fc34.x86_64 libXcomposite-0.4.5-5.fc34.x86_64 libXcursor-1.2.0-5.fc34.x86_64 libXdamage-1.1.5-5.fc34.x86_64 libXext-1.3.4-6.fc34.x86_64 libXfixes-5.0.3-14.fc34.x86_64 libXft-2.3.3-6.fc34.x86_64 libXi-1.7.10-6.fc34.x86_64 libXinerama-1.1.4-8.fc34.x86_64 libXrandr-1.5.2-6.fc34.x86_64 libXrender-0.9.10-14.fc34.x86_64 libblkid-2.36.2-1.fc34.x86_64 libbrotli-1.0.9-4.fc34.x86_64 libcap-2.48-2.fc34.x86_64 libdatrie-0.2.13-1.fc34.x86_64 libffi-3.1-28.fc34.x86_64 libgcc-11.0.0-0.20.fc34.x86_64 libgcrypt-1.9.2-1.fc34.x86_64 libgpg-error-1.41-2.fc34.x86_64 libmount-2.36.2-1.fc34.x86_64 libpng-1.6.37-8.fc34.x86_64 libselinux-3.2-1.fc34.x86_64 libthai-0.1.28-6.fc34.x86_64 libuuid-2.36.2-1.fc34.x86_64 libxcb-1.13.1-7.fc34.x86_64 libxml2-2.9.10-10.fc34.x86_64 libzstd-1.4.9-1.fc34.x86_64 lxappearance-obconf-0.2.3-11.fc34.x86_64 lz4-libs-1.9.3-2.fc34.x86_64 openbox-libs-3.6.1-17.fc34.x86_64 openssl-libs-1.1.1j-1.fc34.x86_64 p11-kit-0.23.22-3.fc34.x86_64 pcre-8.44-3.fc34.1.x86_64 pixman-0.40.0-3.fc34.x86_64 sssd-client-2.4.2-2.fc34.x86_64 systemd-libs-248~rc4-1.fc34.x86_64 xz-libs-5.2.5-5.fc34.x86_64 zlib-1.2.11-24.fc34.x86_64
(gdb) bt
#0  0x000055555555e904 in on_remove_theme_clicked (btn=0x555555750e40, user_data=<optimized out>)
    at /home/tasaka1/rpmbuild/fedora-specific/LXDE/lxappearance/rawhide/lxappearance-0.6.3/lxappearance/src/icon-theme.c:174
#4  0x00007ffff77f4993 in <emit signal ??? on instance ???> (instance=instance@entry=0x555555750e40, signal_id=<optimized out>, detail=detail@entry=0) at ../gobject/gsignal.c:3553
    #1  0x00007ffff77d6c2f in g_closure_invoke (closure=0x5555558112c0, return_value=0x0, n_param_values=1, param_values=0x7fffffffcfe0, invocation_hint=0x7fffffffcf60)
    at ../gobject/gclosure.c:810
    #2  0x00007ffff77f2eb6 in signal_emit_unlocked_R
    (node=node@entry=0x555555643c50, detail=detail@entry=0, instance=instance@entry=0x555555750e40, emission_return=emission_return@entry=0x0, instance_and_params=instance_and_params@entry=0x7fffffffcfe0) at ../gobject/gsignal.c:3741
    #3  0x00007ffff77f477a in g_signal_emit_valist (instance=<optimized out>, signal_id=<optimized out>, detail=<optimized out>, var_args=var_args@entry=0x7fffffffd190)
    at ../gobject/gsignal.c:3497
#5  0x00007ffff7b83272 in IA__gtk_button_clicked (button=button@entry=0x555555750e40) at /usr/src/debug/gtk2-2.24.33-4.fc34.x86_64/gtk/gtkbutton.c:1115
#6  0x00007ffff7b832e6 in gtk_real_button_released (button=0x555555750e40) at /usr/src/debug/gtk2-2.24.33-4.fc34.x86_64/gtk/gtkbutton.c:1712
#7  gtk_real_button_released (button=0x555555750e40) at /usr/src/debug/gtk2-2.24.33-4.fc34.x86_64/gtk/gtkbutton.c:1702
#11 0x00007ffff77f4993 in <emit signal ??? on instance ???> (instance=<optimized out>, signal_id=<optimized out>, detail=detail@entry=0) at ../gobject/gsignal.c:3553
    #8  0x00007ffff77d6c2f in g_closure_invoke (closure=0x5555556437f0, return_value=0x0, n_param_values=1, param_values=0x7fffffffd420, invocation_hint=0x7fffffffd3a0)
    at ../gobject/gclosure.c:810
    #9  0x00007ffff77f2b15 in signal_emit_unlocked_R
    (node=node@entry=0x555555643820, detail=detail@entry=0, instance=instance@entry=0x555555750e40, emission_return=emission_return@entry=0x0, instance_and_params=instance_and_params@entry=0x7fffffffd420) at ../gobject/gsignal.c:3671
    #10 0x00007ffff77f477a in g_signal_emit_valist (instance=<optimized out>, signal_id=<optimized out>, detail=<optimized out>, var_args=var_args@entry=0x7fffffffd5d0)
    at ../gobject/gsignal.c:3497
#12 0x00007ffff7b83eb2 in gtk_button_released (button=<optimized out>) at /usr/src/debug/gtk2-2.24.33-4.fc34.x86_64/gtk/gtkbutton.c:1107
#13 0x00007ffff7b83fa3 in gtk_button_button_release (event=<optimized out>, widget=0x555555750e40) at /usr/src/debug/gtk2-2.24.33-4.fc34.x86_64/gtk/gtkbutton.c:1604
#14 gtk_button_button_release (widget=widget@entry=0x555555750e40, event=<optimized out>) at /usr/src/debug/gtk2-2.24.33-4.fc34.x86_64/gtk/gtkbutton.c:1596
#19 0x00007ffff77f4993 in <emit signal ??? on instance ???> (instance=instance@entry=0x555555750e40, signal_id=<optimized out>, detail=detail@entry=0) at ../gobject/gsignal.c:3553
    #15 0x00007ffff7c44449 in _gtk_marshal_BOOLEAN__BOXED
    (closure=0x5555555e8b00, return_value=0x7fffffffd840, n_param_values=<optimized out>, param_values=0x7fffffffd8a0, invocation_hint=<optimized out>, marshal_data=<optimized out>)
    at /usr/src/debug/gtk2-2.24.33-4.fc34.x86_64/gtk/gtkmarshalers.c:84
    #16 0x00007ffff77d6c2f in g_closure_invoke (closure=0x5555555e8b00, return_value=0x7fffffffd840, n_param_values=2, param_values=0x7fffffffd8a0, invocation_hint=0x7fffffffd820)
    at ../gobject/gclosure.c:810
    #17 0x00007ffff77f28a4 in signal_emit_unlocked_R
    (node=<optimized out>, detail=detail@entry=0, instance=instance@entry=0x555555750e40, emission_return=emission_return@entry=0x7fffffffd9c0, instance_and_params=instance_and_params@entry=0x7fffffffd8a0) at ../gobject/gsignal.c:3780
    #18 0x00007ffff77f42ee in g_signal_emit_valist (instance=<optimized out>, signal_id=<optimized out>, detail=<optimized out>, var_args=var_args@entry=0x7fffffffda70)
    at ../gobject/gsignal.c:3507
#20 0x00007ffff7d87144 in gtk_widget_event_internal (widget=0x555555750e40, event=0x555555d1f710) at /usr/src/debug/gtk2-2.24.33-4.fc34.x86_64/gtk/gtkwidget.c:5017
#21 0x00007ffff7c46fc4 in IA__gtk_propagate_event (widget=0x555555750e40, event=0x555555d1f710) at /usr/src/debug/gtk2-2.24.33-4.fc34.x86_64/gtk/gtkmain.c:2503
#22 0x00007ffff7c48c93 in IA__gtk_main_do_event (event=0x555555d1f710) at /usr/src/debug/gtk2-2.24.33-4.fc34.x86_64/gtk/gtkmain.c:1698
#23 IA__gtk_main_do_event (event=<optimized out>) at /usr/src/debug/gtk2-2.24.33-4.fc34.x86_64/gtk/gtkmain.c:1503
#24 0x00007ffff7a89673 in gdk_event_dispatch (source=<optimized out>, callback=<optimized out>, user_data=<optimized out>) at x11/gdkevents-x11.c:2425
#25 0x00007ffff76de377 in g_main_dispatch (context=0x5555555b6780) at ../glib/gmain.c:3337
#26 g_main_context_dispatch (context=0x5555555b6780) at ../glib/gmain.c:4055
#27 0x00007ffff77322c8 in g_main_context_iterate.constprop.0 (context=0x5555555b6780, block=block@entry=1, dispatch=dispatch@entry=1, self=<optimized out>) at ../glib/gmain.c:4131
#28 0x00007ffff76dd943 in g_main_loop_run (loop=0x55555581dea0) at ../glib/gmain.c:4329
--Type <RET> for more, q to quit, c to continue without paging--
#29 0x00007ffff7c42142 in IA__gtk_main () at /usr/src/debug/gtk2-2.24.33-4.fc34.x86_64/gtk/gtkmain.c:1270
#30 0x000055555555ac20 in main (argc=<optimized out>, argv=<optimized out>)
    at /home/tasaka1/rpmbuild/fedora-specific/LXDE/lxappearance/rawhide/lxappearance-0.6.3/lxappearance/src/lxappearance.c:702
```