### PR TITLE
fix(gtk3): fix GTK-3 segfault

### DIFF
--- a/src/cursor-theme.c
+++ b/src/cursor-theme.c
@@ -22,6 +22,7 @@
 #include "cursor-theme.h"
 #include "icon-theme.h"
 #include "lxappearance.h"
+#include <cairo/cairo-xlib.h>
 #include <gdk/gdkx.h>
 
 static void update_cursor_demo()

--- a/src/lxappearance.c
+++ b/src/lxappearance.c
@@ -32,6 +32,7 @@
 #include <X11/X.h>
 #include <X11/Xatom.h>
 #include <X11/Xlib.h>
+#include <cairo/cairo-xlib.h>
 #include <gdk/gdkx.h>
 #include <string.h>
 


### PR DESCRIPTION
Forward patch for https://bugs.debian.org/1052210 to fix GTK-3 segfault.

The bug report is in https://sourceforge.net/p/lxde/bugs/967/, and patch is provided by Ingo Brückl.